### PR TITLE
More granular capacity control

### DIFF
--- a/esphome/clack_dv/.clack-base.yaml
+++ b/esphome/clack_dv/.clack-base.yaml
@@ -1951,7 +1951,7 @@ number:
     icon: mdi:water-opacity
     optimistic: true
     mode: slider
-    step: 100
+    step: 50
     entity_category: config
     min_value: 0
     max_value: 12000


### PR DESCRIPTION
For my LESS-15, capacity is 5250 on the valve, but currently, I can only set it to 5200 or 5300 on the clack reader. This should allow me to set it to 5250.