### PR TITLE
Improve readme files and change 'Capacity in gallons' to textbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,20 @@
 # Clack Reader v4
- Esphome component for Clack WS PI (disc valve) Ecosoft LESS and WS1 softener with M5stack TOF sensor saltlevel detection
+ ESPHome component for Clack WS PI (disc valve) Ecosoft LESS and WS1 valves.
  
- Relay for control of the chlorinator module from AQMOS
- and Power measurement with ina3221
+ Features:
+ - Salt level detection from M5stack TOF (time of flight) sensor
+ - AQMOS chlorinator module control using a relay
+ - Recognition of softener steps via INA3221 power measurement
+ - Measurement of water flow rate (L/min or gal/min) and softener capacity remaining (m<sup>3</sup> or gal) by reading the Clack flowmeter
 
- Automatic recognision of the softener steps and measure the liters and m3 softened water by reading the clack flowmeter
+## Versions / Branches
+- **main**: Clack WS PI valve (DiscValve) (ECOSOFT LESS-10 / 15 / 20 from AQMOS)
+- **ws1**: Clack WS1 valve (CM(x) from AQMOS)
+- **ws1_usa**: Clack WS1 valve with gallons and inches (US version)
+- **ws1_no_tof**: Clack WS1 valve without the TOF sensor code (in case of TOF failure/damaged by water)
 
-## 4 Versions / Branches
-main: Clack WS PI valve (DiscValve) (ECOSOFT LESS-10 / 15 / 20 from AQMOS)
-
-ws1: Clack WS1 valve (CM(x) from AQMOS)
-
-ws1_usa: Clack WS1 valve with Gallons and Inches / US version
-
-ws1_no_tof: Clack WS1 valve without the TOF sensor code (in case of TOF failure/damaged by water)
-
-Remark: Make sure to copy water_flow_gallons.h and tof_vl53l1x.h to your esphome directory before compiling the clack.yaml
-There have been some bigger updates to the latest code: added L/min and alarm, also lovelace home assistant menu has been updated.
+Remark: Make sure to copy water_flow_gallons.h and tof_vl53l1x.h to your ESPHome directory before compiling the clack.yaml
+There have been some bigger updates to the latest code: added L/min and alarm, also lovelace Home Assistant menu has been updated.
 
 Remark2: 6 august 2024: Added history regeneration and test button motor pulse to step through regeneration (with time delays stil working between steps)
 
@@ -137,11 +135,11 @@ web_server:
 ```
 
 ## Installation
-You will first need to do a manual installation by putting the clack.yaml file into your esphome folder then using the modern format in ESPHome to get a local copy of the firmware and finally use https://web.esphome.io/ to install over USB.
-Also copy the files tof_vl53l1x.h and water_flow_gallons.h to you're esphome directory as they are needed for the flow meter calculation and distance TOF sensor.
+You will first need to do a manual installation by putting the clack.yaml file into your ESPHome folder then using the modern format in ESPHome to get a local copy of the firmware and finally use https://web.esphome.io/ to install over USB.
+Also copy the files tof_vl53l1x.h and water_flow_gallons.h to you're ESPHome directory as they are needed for the flow meter calculation and distance TOF sensor.
 
 ### Method
-Download a copy of this code and place it in your esphome folder. Also place the clack.yaml - secrets.yaml - water_flow_gallons.h and tof_vl53l1x.h into the esphome folder, ensuring to change the secrets.yaml details to your own credentials.
+Download a copy of this code and place it in your ESPHome folder. Also place the clack.yaml - secrets.yaml - water_flow_gallons.h and tof_vl53l1x.h into the ESPHome folder, ensuring to change the secrets.yaml details to your own credentials.
 
 From your ESPHome dashboard, create a local copy of the clack firmware (bin file) by clicking the three dots > Install > Manual Download > Modern Format
 

--- a/esphome/clack_ws1_usa/.clack-base.yaml
+++ b/esphome/clack_ws1_usa/.clack-base.yaml
@@ -1940,8 +1940,8 @@ number:
     name: ${clack_capacity_gallons}
     icon: mdi:water-opacity
     optimistic: true
-    mode: slider
-    step: 50
+    mode: box
+    step: 5
     entity_category: config
     min_value: 0
     max_value: 4000

--- a/readme/clack_explanation_en.md
+++ b/readme/clack_explanation_en.md
@@ -98,8 +98,8 @@ The sensor measures the distance downwards to the salt. That measured distance s
 Because of this, shorter distances are not recorded as the most recent value, only longer ones. This way, water rising above the salt does not affect the measurement.
 
 There are two readings: Distance and TOF Distance.
-Distance is the measurement with the smart function. TOF Distance is continuously measured every 10 seconds but has no effect on the 'Clack salt level percent' and does not affect Distance unless the it measures greater than Distance.
+Distance is the measurement with the smart function. TOF Distance is continuously measured every 10 seconds but has no effect on the 'Clack salt level percent' and does not affect Distance unless it measures greater than Distance.
 
 ### Refilling Salt
 
-When refilling your salt container, press the 'Reset fill salt' button on the dashboard. This will equalize the TOF Distance and Distance values, thereby resetting the distance measurement so that the new salt level can be measured and recorded again. Recall that the smart function would otherwise not let Distance increase.
+When refilling your salt container, press the 'Reset fill salt' button on the dashboard. This will equalize the TOF Distance and Distance values, thereby resetting the distance measurement so that the new salt level can be measured and recorded again. Recall that the smart function would otherwise not let Distance decrease.


### PR DESCRIPTION
- Additional organization in the readme.md. Fix typos in clack_explanation_en.md from earlier commit.
- Changed the slider for 'capacity in gallons' from a slider to a textbox. It bothered me that I can only set it to 1250 with the slider, when the Clack capacity is 1285.
 
Fair warning, I did not test compiling the capacity UI change to the device because I haven't figured out how to do that yet. However I did use the HA developer tools UI to apply the change temporarily and confirm it worked.