### PR TITLE
fix: pulse test button for testing water meter

### DIFF
--- a/esphome/clack_dv/.clack-base.yaml
+++ b/esphome/clack_dv/.clack-base.yaml
@@ -15,13 +15,11 @@ api:
       variables:
         meter_value: float
       then:
-        - lambda: |-
-            id(totalWaterUsage) = float(meter_value);
-        - component.update: clack_watermeter_total
         - pulse_meter.set_total_pulses:
             id: clack_flow_rate
             value: !lambda |-
-              return id(totalWaterUsage) * id(pulse_per_liter);
+              id(water_meter_force_overwrite) = true;
+              return float(meter_value) * id(pulse_per_liter);
 
     - action: last_distance_value #set last measured salt distance to any value in cm.
       variables:
@@ -108,6 +106,12 @@ globals:
   - id: water_meter_freeze
     type: bool
     restore_value: yes
+    initial_value: 'false'
+
+  # Define a global variable to force overwrite the totalWaterUsage value
+  - id: water_meter_force_overwrite
+    type: bool
+    restore_value: no
     initial_value: 'false'
 
   # Define a global variable that shows motor run
@@ -282,13 +286,11 @@ script:
   - id: reset_water_meter
     mode: restart
     then:
-      - lambda: |-
-          id(totalWaterUsage) = 0.0;
-      - component.update: clack_watermeter_total
       - pulse_meter.set_total_pulses:
           id: clack_flow_rate
           value: !lambda |-
-            return id(totalWaterUsage) * id(pulse_per_liter);
+            id(water_meter_force_overwrite) = true;
+            return 0;
 
   ### Define a script that visualize the cycle steps in regeneration
   # Script "decide_cycle"

--- a/esphome/clack_dv/.waterflow.yaml
+++ b/esphome/clack_dv/.waterflow.yaml
@@ -39,10 +39,14 @@ sensor:
             return x / id(pulse_per_liter);
       on_value:
         then:
-          # Prevent the global 'totalWaterUsage' from being overwritten by 0.
           # The pulse_meter sensor returns 0 on reboot or flash, which would result in a reset of 'totalWaterUsage'
+          # Prevent the global 'totalWaterUsage' from being overwritten by 0.
+          # Only allow writing a value greater than 0, except when an update is forced (e.g. at a water meter reset)
           - lambda: |-
-              if (id(clack_watermeter).state > 0) {
+              ESP_LOGI("main", "Value of 'clack_watermeter': %f", id(clack_watermeter).state);
+              ESP_LOGI("main", "Force overwrite 'totalWaterUsage'? %s", id(water_meter_force_overwrite) ? "Yes" : "No");
+              if (id(water_meter_force_overwrite) || id(clack_watermeter).state > 0) {
                 id(totalWaterUsage) = id(clack_watermeter).state;
+                id(water_meter_force_overwrite) = false;
               }
           - component.update: clack_watermeter_total

--- a/esphome/clack_dv/board-esp32-atom-s3.yaml
+++ b/esphome/clack_dv/board-esp32-atom-s3.yaml
@@ -31,16 +31,19 @@ binary_sensor:
       - delayed_on_off: 50ms
     on_press:
       then:
+        - lambda: |-
+            ESP_LOGI("main", "Water meter freeze? %s", id(water_meter_freeze) ? "Yes" : "No");
         - if:
             condition:
               lambda: 'return id(water_meter_freeze) == false;'
             then:
-              - sensor.template.publish:
-                  id: clack_watermeter
-                  state: !lambda |-
-                    return id(totalWaterUsage) += 0.1;
-              - lambda: |-
-                  ESP_LOGI("UseTest", "Use button pressed");
+              # We have to calculate the number of pulses by multiplying the liters with the pulse per liter setting.
+              # Because of the precision of 1 decimal for the total sensor, adding 0.1 L is not always visible.
+              # The pulse_meter sensor has a precision of 2 decimals, which is a little more precise.
+              - pulse_meter.set_total_pulses:
+                  id: clack_flow_rate
+                  value: !lambda |-
+                    return (id(totalWaterUsage) + 0.1) * id(pulse_per_liter);
 
   # Binary sensor "init_state"
   - platform: template
@@ -75,11 +78,13 @@ button:
     id: clack_use_tst_but
     on_press:
       then:
-        - lambda: |-
-            id(clack_use_test_button).publish_state(true);
+        - binary_sensor.template.publish:
+            id: clack_use_test_button
+            state: true
         - delay: 100ms
-        - lambda: |-
-            id(clack_use_test_button).publish_state(false);
+        - binary_sensor.template.publish:
+            id: clack_use_test_button
+            state: false
 
   # Button "clack_resinclean_reset_button"
   - platform: template


### PR DESCRIPTION
The `Test button use pulse` was incorrectly updating the `pulse_meter` total pulses. It was setting the pulse meter to the number of liters instead of the number of liters multiplied by the pulses per liter.

When adding more logging, I also stumbled upon the fact that the water meter update was triggered twice. Once by setting the global value `totalWaterUsage` directly end once by updating the `set_total_pulses` of the total sensor.

This has been fixed by only letting the total sensor set the global value. By passing the a new value for the water meter multiplied by the pulses per liter, the trigger for the water meter is now only done once.

Another issue I faced was that the water meter reset did not trigger a reset for the `totalWaterUsage`. By adding a flag to force overwrite the water meter from within the API or the reset script, the total water usage is now forces to be set. In this case, on reboot an empty value from the pulse meter does not reset the water meter.