### PR TITLE
Fix indentation in .tof2.yaml on_value block

### DIFF
--- a/esphome/clack_ws1_usa/.tof2.yaml
+++ b/esphome/clack_ws1_usa/.tof2.yaml
@@ -51,9 +51,9 @@ sensor:
 #        - median:
       - delta: 0.2
       - lambda: return (x* 0.39370079); # cm to inch
-      on_value:
-        then:
-          - sensor.template.publish:
-              id: clack_distance
-              state: !lambda |-
-                return id(distance_in).state;
+    on_value:
+      then:
+        - sensor.template.publish:
+            id: clack_distance
+            state: !lambda |-
+              return id(distance_in).state;


### PR DESCRIPTION
The incorrect indentation caused the device to enter a boot loop when flashed to the device. Fixing the indentation and re-flashing over usb-c resolved the boot loop.