### PR TITLE
Fix formatting of chlorinator label to support ESPHome 2026.7+

### DIFF
--- a/esphome/clack_ws1_usa/.clack-base.yaml
+++ b/esphome/clack_ws1_usa/.clack-base.yaml
@@ -1316,7 +1316,7 @@ sensor:
   - platform: custom
     lambda: |-
       auto wf = new WaterFlowSensor();
-      App.register_component(wf);
+      App.register_component_(wf);
       return {wf->clack_flow_rate};
 
     sensors:

--- a/esphome/clack_ws1_usa/.clack-labels-en.yaml
+++ b/esphome/clack_ws1_usa/.clack-labels-en.yaml
@@ -29,7 +29,7 @@ substitutions:
   clack_wifi_signal_db_percent: WiFi Signal
   clack_uptime: Uptime
   clack_chlorinator: Chlorinator
-  clack_chlorinator_sw: Chlorinator / DP-SW
+  clack_chlorinator_sw: Chlorinator ⁄ DP-SW
   clack_dp_sw_init_regen: DP-SW Initialise regen
   clack_dp_sw_hold_regen: DP-SW Hold regen
   clack_dp_sw_init_hold: DP-SW Activate


### PR DESCRIPTION
Handle ESPHome warning: WARNING 'Chlorinator / DP-SW' contains '/' which is reserved as a URL path separator. Automatically replacing with 'Chlorinator ⁄ DP-SW' (Unicode FRACTION SLASH). Please update your configuration. This will become an error in ESPHome 2026.7.0.