### PR TITLE
added: execute reset_water_meter script after regen finished (after set delay in state transition logic)

### DIFF
--- a/esphome/clack_ws1/.clack-base.yaml
+++ b/esphome/clack_ws1/.clack-base.yaml
@@ -462,6 +462,7 @@ script:
       - component.update: timer1
       - component.update: timer2
       - delay: 30s
+      - script.execute: reset_water_meter
       - lambda: 'id(wait_on_delay) = false;'
       - lambda: 'id(water_meter_freeze) = false;'
 
@@ -628,6 +629,7 @@ script:
       - component.update: timer1
       - component.update: timer2
       - delay: 30s
+      - script.execute: reset_water_meter
       - lambda: 'id(wait_on_delay) = false;'
       - lambda: 'id(water_meter_freeze) = false;'
 
@@ -787,6 +789,7 @@ script:
       - component.update: timer1
       - component.update: timer2
       - delay: 30s
+      - script.execute: reset_water_meter
       - lambda: 'id(wait_on_delay) = false;'
       - lambda: 'id(water_meter_freeze) = false;'
 
@@ -969,6 +972,7 @@ script:
       - component.update: timer1
       - component.update: timer2
       - delay: 30s
+      - script.execute: reset_water_meter
       - lambda: 'id(wait_on_delay) = false;'
       - lambda: 'id(water_meter_freeze) = false;'
       
@@ -1128,6 +1132,7 @@ script:
       - component.update: timer1
       - component.update: timer2
       - delay: 30s
+      - script.execute: reset_water_meter
       - lambda: 'id(wait_on_delay) = false;'
       - lambda: 'id(water_meter_freeze) = false;'
       
@@ -1287,6 +1292,7 @@ script:
       - component.update: timer1
       - component.update: timer2
       - delay: 30s
+      - script.execute: reset_water_meter
       - lambda: 'id(wait_on_delay) = false;'
       - lambda: 'id(water_meter_freeze) = false;'
 


### PR DESCRIPTION
I have frequent water meter initial tiny usage after regen finished, I suppose it because water flowing at the regen start lead to hold some usage in memory. 
This leads to lowered initial capacity compared to real Clack counter (starts with 0 after regen).
So just added additional water meter reset at regen finish to minimize code changes 
- just calling again built in reset_water_meter script  at the regen end.