### PR TITLE
Fix ESPHome deprecation warnings: select.state and sensor.raw_state 2026.10, Fix -Wformat warning in std::string fallback log messages 2026.7, Fix wait scripts from 10 to 20 sec 

### DIFF
--- a/esphome/clack_dv/.clack-base.yaml
+++ b/esphome/clack_dv/.clack-base.yaml
@@ -1492,7 +1492,7 @@ text_sensor:
       int64_t operation_time = int(id(clack_save_total_operation_time).state);
       
       if (operation_time <= 0) {
-        ESP_LOGI("main", "Fallback to 'save_total_time_used' since the new 'save_total_operation_time' does not have the operation time set yet: %f", id(save_total_time_used));
+        ESP_LOGI("main", "Fallback to 'save_total_time_used' since the new 'save_total_operation_time' does not have the operation time set yet: %s", id(save_total_time_used).c_str());
         return std::string(id(save_total_time_used));
       }
       

--- a/esphome/clack_dv/.clack-base.yaml
+++ b/esphome/clack_dv/.clack-base.yaml
@@ -521,7 +521,7 @@ script:
   - id: continue_brine_cycle
     mode: single
     then:
-      - delay: 10s
+      - delay: 20s
       - wait_until:
           condition:
             binary_sensor.is_on: bin_sens_motor_run
@@ -544,7 +544,7 @@ script:
   - id: continue_backwash_cycle
     mode: single
     then:
-      - delay: 10s
+      - delay: 20s
       - wait_until:
           condition:
             binary_sensor.is_on: bin_sens_motor_run
@@ -567,7 +567,7 @@ script:
   - id: continue_backwash2_cycle
     mode: single
     then:
-      - delay: 10s
+      - delay: 20s
       - wait_until:
           condition:
             binary_sensor.is_on: bin_sens_motor_run
@@ -590,7 +590,7 @@ script:
   - id: continue_rinse_cycle
     mode: single
     then:
-      - delay: 10s
+      - delay: 20s
       - wait_until:
           condition:
             binary_sensor.is_on: bin_sens_motor_run
@@ -613,7 +613,7 @@ script:
   - id: continue_fill_cycle
     mode: single
     then:
-      - delay: 10s
+      - delay: 20s
       - wait_until:
           condition:
             binary_sensor.is_on: bin_sens_motor_run
@@ -636,7 +636,7 @@ script:
   - id: continue_service_cycle
     mode: single
     then:
-      - delay: 10s
+      - delay: 20s
       - wait_until:
           condition:
             binary_sensor.is_on: bin_sens_motor_run

--- a/esphome/clack_dv/.clack-labels-en.yaml
+++ b/esphome/clack_dv/.clack-labels-en.yaml
@@ -111,7 +111,7 @@ text_sensor:
     lambda: |-
       time_t datetime = id(saltfill_last);
       if (datetime <= 0) {
-        ESP_LOGI("main", "Fallback to 'fill_last' since the new 'saltfill_last' does not have the salt fill time set yet: %f", id(fill_last));
+        ESP_LOGI("main", "Fallback to 'fill_last' since the new 'saltfill_last' does not have the salt fill time set yet: %s", id(fill_last).c_str());
         return std::string(id(fill_last));
       }
       ${format_datetime_readable}

--- a/esphome/clack_dv/.clack-labels-fr.yaml
+++ b/esphome/clack_dv/.clack-labels-fr.yaml
@@ -154,7 +154,7 @@ text_sensor:
     lambda: |-
       time_t datetime = id(saltfill_last);
       if (datetime <= 0) {
-        ESP_LOGI("main", "Fallback to 'fill_last' since the new 'saltfill_last' does not have the salt fill time set yet: %f", id(fill_last));
+        ESP_LOGI("main", "Fallback to 'fill_last' since the new 'saltfill_last' does not have the salt fill time set yet: %s", id(fill_last).c_str());
         return std::string(id(fill_last));
       }
       ${format_datetime_readable}

--- a/esphome/clack_dv/.clack-labels-nl.yaml
+++ b/esphome/clack_dv/.clack-labels-nl.yaml
@@ -153,7 +153,7 @@ text_sensor:
     lambda: |-
       time_t datetime = id(saltfill_last);
       if (datetime <= 0) {
-        ESP_LOGI("main", "Fallback to 'fill_last' since the new 'saltfill_last' does not have the salt fill time set yet: %f", id(fill_last));
+        ESP_LOGI("main", "Fallback to 'fill_last' since the new 'saltfill_last' does not have the salt fill time set yet: %s", id(fill_last).c_str());
         return std::string(id(fill_last));
       }
       ${format_datetime_readable}

--- a/esphome/clack_dv/.waterflow.yaml
+++ b/esphome/clack_dv/.waterflow.yaml
@@ -15,7 +15,7 @@ sensor:
     on_value:
       then:
         - lambda: |-
-            ESP_LOGI("main", "Raw value of 'clack_flow_rate': %f", id(clack_flow_rate).raw_state);
+            ESP_LOGI("main", "Raw value of 'clack_flow_rate': %f", id(clack_flow_rate).get_raw_state());
             ESP_LOGI("main", "Filtered value of 'clack_flow_rate': %f", id(clack_flow_rate).state);
     timeout: 6.5s
     icon: mdi:waves-arrow-right


### PR DESCRIPTION
Here a few fixes for esphome 2026.7 and 2026.10.

I also changed the wait time scripts from 10 to 20 sec because i have sometimes 3 spikes with a cycle change in power that are within 15 secs so it skips a step.
<img width="1206" height="783" alt="image" src="https://github.com/user-attachments/assets/bf9a3cfc-64e2-441f-98a2-6ec6b33f4d41" />
