### PR TITLE
Restore max-hold filter on clack_distance (regression from 832c0b6)

### DIFF
--- a/esphome/clack_dv/.clack-base.yaml
+++ b/esphome/clack_dv/.clack-base.yaml
@@ -743,6 +743,8 @@ binary_sensor:
       } else {
         return false;
       }
+    filters:
+      - delayed_off: 500ms
 
   - platform: template
     name: ${clack_water_flowing}

--- a/esphome/clack_dv/.tof1.yaml
+++ b/esphome/clack_dv/.tof1.yaml
@@ -36,5 +36,8 @@ sensor:
     on_value:
       then:
         - lambda: |-
-            id(last_distance) = float(x);
+            float new_distance = float(x);
+            if (id(last_distance) <= 0.0 || new_distance >= id(last_distance)) {
+              id(last_distance) = new_distance;
+            }
         - component.update: clack_distance

--- a/esphome/clack_dv/.tof2.yaml
+++ b/esphome/clack_dv/.tof2.yaml
@@ -52,5 +52,8 @@ sensor:
     on_value:
       then:
         - lambda: |-
-            id(last_distance) = float(x);
+            float new_distance = float(x);
+            if (id(last_distance) <= 0.0 || new_distance >= id(last_distance)) {
+              id(last_distance) = new_distance;
+            }
         - component.update: clack_distance

--- a/esphome/clack_dv/board-esp32-atom-s3.yaml
+++ b/esphome/clack_dv/board-esp32-atom-s3.yaml
@@ -133,7 +133,9 @@ button:
     id: clack_reset_but_last_dist
     on_press:
       then:
-        - component.update: clack_distance_tof
+        - lambda: |-
+            id(last_distance) = id(clack_distance_tof).state;
+        - component.update: clack_distance
         - lambda: |-
             id(saltfill_last) = id(sntp_time).now().timestamp;
         - component.update: clack_saltfill_last


### PR DESCRIPTION
clack_distance mirrored clack_distance_tof 1:1 since the Aug 2025 refactor dropped the filter that only accepted a growing distance (salt depleting) and held on sudden decreases (noise) unless manually confirmed via the "Reset fill salt" reset button.

<img width="1096" height="666" alt="2026-08-14_10h54_37" src="https://github.com/user-attachments/assets/c3c3ead3-03a7-48c1-b7db-f3c23fa33215" />

Screenshot of my test after flashing this fix:

Around 10:07 (old code, before flashing): both "salt distance" and "distance TOF" move identically — confirming the bug, since there was no filtering between them.

Around 10:43 I flashed the new code. Distance TOF briefly drops to 0 right after flashing, which is normal sensor startup behavior. Salt distance, however, stayed at its last known value — exactly as expected, since it's restored from flash and correctly rejects the invalid 0 reading.

At 10:47 I lifted the sensor to simulate a larger distance: both lines rise together, as expected (an increase is always accepted). When I put the sensor back to its original position, distance TOF dropped back down immediately, but salt distance stayed at the higher value — confirming the max-hold filter is working. At 10:53 I pressed the reset button ("Reset fill salt"), and both lines converge again, with the salt percentage updating accordingly.

This confirms the fix restores the original intended behavior.